### PR TITLE
More granular thresholds

### DIFF
--- a/cloudsweeper/cleanup/cleanup.go
+++ b/cloudsweeper/cleanup/cleanup.go
@@ -41,19 +41,27 @@ func MarkForCleanup(mngr cloud.ResourceManager, thresholds map[string]int) {
 		untaggedFilter.AddSnapshotRule(filter.IsNotInUse())
 		untaggedFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
 
-		oldFilter := filter.New()
-		oldFilter.AddGeneralRule(filter.OlderThanXMonths(thresholds["clean-general-older-than-months"]))
-		// Don't cleanup resources tagged for release
-		oldFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
-		oldFilter.AddSnapshotRule(filter.IsNotInUse())
-		oldFilter.AddVolumeRule(filter.IsUnattached())
-		oldFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
+		instanceFilter := filter.New()
+		instanceFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["clean-instances-older-than-days"]))
+		instanceFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
+		instanceFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
 
-		unattachedFilter := filter.New()
-		unattachedFilter.AddVolumeRule(filter.IsUnattached())
-		unattachedFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["clean-unattatched-older-than-days"]))
-		unattachedFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
-		unattachedFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
+		snapshotFilter := filter.New()
+		instanceFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["clean-snapshots-older-than-days"]))
+		snapshotFilter.AddSnapshotRule(filter.IsNotInUse())
+		snapshotFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
+		snapshotFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
+
+		imageFilter := filter.New()
+		imageFilter.AddGeneralRule(filter.OlderThanXDays(threholds["clean-images-older-than-days"]))
+		imageFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
+		imageFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
+
+		volumeFilter := filter.New()
+		volumeFilter.AddVolumeRule(filter.IsUnattached())
+		volumeFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["clean-unattatched-older-than-days"]))
+		volumeFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
+		volumeFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
 
 		bucketFilter := filter.New()
 		bucketFilter.AddBucketRule(filter.NotModifiedInXDays(thresholds["clean-bucket-not-modified-days"]))
@@ -67,7 +75,7 @@ func MarkForCleanup(mngr cloud.ResourceManager, thresholds map[string]int) {
 		totalCost := 0.0
 
 		// Tag instances
-		for _, res := range filter.Instances(res.Instances, untaggedFilter) {
+		for _, res := range filter.Instances(res.Instances, instanceFilter, untaggedFilter) {
 			resourcesToTag = append(resourcesToTag, res)
 			days := time.Now().Sub(res.CreationTime()).Hours() / 24.0
 			costPerDay := billing.ResourceCostPerDay(res)
@@ -75,7 +83,7 @@ func MarkForCleanup(mngr cloud.ResourceManager, thresholds map[string]int) {
 		}
 
 		// Tag volumes
-		for _, res := range filter.Volumes(res.Volumes, oldFilter, unattachedFilter) {
+		for _, res := range filter.Volumes(res.Volumes, volumeFilter) {
 			resourcesToTag = append(resourcesToTag, res)
 			days := time.Now().Sub(res.CreationTime()).Hours() / 24.0
 			costPerDay := billing.ResourceCostPerDay(res)
@@ -83,7 +91,7 @@ func MarkForCleanup(mngr cloud.ResourceManager, thresholds map[string]int) {
 		}
 
 		// Tag snapshots
-		for _, res := range filter.Snapshots(res.Snapshots, oldFilter, untaggedFilter) {
+		for _, res := range filter.Snapshots(res.Snapshots, snapshotFilter, untaggedFilter) {
 			resourcesToTag = append(resourcesToTag, res)
 			days := time.Now().Sub(res.CreationTime()).Hours() / 24.0
 			costPerDay := billing.ResourceCostPerDay(res)
@@ -91,7 +99,7 @@ func MarkForCleanup(mngr cloud.ResourceManager, thresholds map[string]int) {
 		}
 
 		// Tag images
-		for _, res := range filter.Images(res.Images, oldFilter, untaggedFilter) {
+		for _, res := range filter.Images(res.Images, imageFilter, untaggedFilter) {
 			resourcesToTag = append(resourcesToTag, res)
 			days := time.Now().Sub(res.CreationTime()).Hours() / 24.0
 			costPerDay := billing.ResourceCostPerDay(res)

--- a/cloudsweeper/cleanup/cleanup.go
+++ b/cloudsweeper/cleanup/cleanup.go
@@ -53,7 +53,7 @@ func MarkForCleanup(mngr cloud.ResourceManager, thresholds map[string]int) {
 		snapshotFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
 
 		imageFilter := filter.New()
-		imageFilter.AddGeneralRule(filter.OlderThanXDays(threholds["clean-images-older-than-days"]))
+		imageFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["clean-images-older-than-days"]))
 		imageFilter.AddGeneralRule(filter.Negate(filter.HasTag(releaseTag)))
 		imageFilter.AddGeneralRule(filter.Negate(filter.TaggedForCleanup()))
 

--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -152,7 +152,7 @@ func (c *Client) OldResourceReview(mngr cloud.ResourceManager, org *cs.Organizat
 
 	whitelistFilter := filter.New()
 	whitelistFilter.OverrideWhitelist = true
-	whitelistFilter.AddGeneralRule(filter.OlderThanXMonths(thresholds["notify-whitelist-older-than-months"]))
+	whitelistFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-whitelist-older-than-days"]))
 
 	// These only apply to instances
 	dndFilter := filter.New()

--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -132,34 +132,36 @@ func (c *Client) OldResourceReview(mngr cloud.ResourceManager, org *cs.Organizat
 	totalSummaryMailData := initTotalSummaryMailData(c.config.TotalSumAddresse)
 	managerToMailDataMapping := initManagerToMailDataMapping(org.Managers)
 
+	log.Println(thresholds)
+
 	// Create filters
 	instanceFilter := filter.New()
-	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["InstancesOlderThanDays"]))
+	instanceFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-instances-older-than-days"]))
 
 	imageFilter := filter.New()
-	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["ImagesOlderThanDays"]))
+	imageFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-images-older-than-days"]))
 
 	volumeFilter := filter.New()
-	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["VolumesOlderThanDays"]))
+	volumeFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-volumes-older-than-days"]))
 
 	snapshotFilter := filter.New()
-	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["SnapshotsOlderThanDays"]))
+	snapshotFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-snapshots-older-than-days"]))
 
 	bucketFilter := filter.New()
-	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["BucketsOlderThanDays"]))
+	bucketFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-buckets-older-than-days"]))
 
 	whitelistFilter := filter.New()
 	whitelistFilter.OverrideWhitelist = true
-	whitelistFilter.AddGeneralRule(filter.OlderThanXMonths(thresholds["WhitelistOlderThanMonths"]))
+	whitelistFilter.AddGeneralRule(filter.OlderThanXMonths(thresholds["notify-whitelist-older-than-months"]))
 
 	// These only apply to instances
 	dndFilter := filter.New()
 	dndFilter.AddGeneralRule(filter.HasTag("no-not-delete"))
-	dndFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["DndOlderThanDays"]))
+	dndFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-dnd-older-than-days"]))
 
 	dndFilter2 := filter.New()
 	dndFilter2.AddGeneralRule(filter.NameContains("do-not-delete"))
-	dndFilter2.AddGeneralRule(filter.OlderThanXDays(thresholds["DndOlderThanDays"]))
+	dndFilter2.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-dnd-older-than-days"]))
 
 	for account, resources := range allCompute {
 		log.Println("Performing old resource review in", account)

--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -140,7 +140,8 @@ func (c *Client) OldResourceReview(mngr cloud.ResourceManager, org *cs.Organizat
 	imageFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-images-older-than-days"]))
 
 	volumeFilter := filter.New()
-	volumeFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-volumes-older-than-days"]))
+	volumeFilter.AddVolumeRule(filter.IsUnattached())
+	volumeFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-unattached-older-than-days"]))
 
 	snapshotFilter := filter.New()
 	snapshotFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-snapshots-older-than-days"]))

--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -133,8 +133,20 @@ func (c *Client) OldResourceReview(mngr cloud.ResourceManager, org *cs.Organizat
 	managerToMailDataMapping := initManagerToMailDataMapping(org.Managers)
 
 	// Create filters
-	generalFilter := filter.New()
-	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["GeneralOlderThanDays"]))
+	instanceFilter := filter.New()
+	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["InstancesOlderThanDays"]))
+
+	imageFilter := filter.New()
+	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["ImagesOlderThanDays"]))
+
+	volumeFilter := filter.New()
+	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["VolumesOlderThanDays"]))
+
+	snapshotFilter := filter.New()
+	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["SnapshotsOlderThanDays"]))
+
+	bucketFilter := filter.New()
+	generalFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["BucketsOlderThanDays"]))
 
 	whitelistFilter := filter.New()
 	whitelistFilter.OverrideWhitelist = true
@@ -157,14 +169,14 @@ func (c *Client) OldResourceReview(mngr cloud.ResourceManager, org *cs.Organizat
 		// Apply filters
 		userMailData := resourceMailData{
 			Owner:     username,
-			Instances: filter.Instances(resources.Instances, generalFilter, whitelistFilter, dndFilter, dndFilter2),
-			Images:    filter.Images(resources.Images, generalFilter, whitelistFilter),
-			Volumes:   filter.Volumes(resources.Volumes, generalFilter, whitelistFilter),
-			Snapshots: filter.Snapshots(resources.Snapshots, generalFilter, whitelistFilter),
+			Instances: filter.Instances(resources.Instances, instanceFilter, whitelistFilter, dndFilter, dndFilter2),
+			Images:    filter.Images(resources.Images, imageFilter, whitelistFilter),
+			Volumes:   filter.Volumes(resources.Volumes, volumeFilter, whitelistFilter),
+			Snapshots: filter.Snapshots(resources.Snapshots, snapshotFilter, whitelistFilter),
 			Buckets:   []cloud.Bucket{},
 		}
 		if buckets, ok := allBuckets[account]; ok {
-			userMailData.Buckets = filter.Buckets(buckets, generalFilter, whitelistFilter)
+			userMailData.Buckets = filter.Buckets(buckets, bucketFilter, whitelistFilter)
 		}
 
 		// Add to the manager summary

--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -132,8 +132,6 @@ func (c *Client) OldResourceReview(mngr cloud.ResourceManager, org *cs.Organizat
 	totalSummaryMailData := initTotalSummaryMailData(c.config.TotalSumAddresse)
 	managerToMailDataMapping := initManagerToMailDataMapping(org.Managers)
 
-	log.Println(thresholds)
-
 	// Create filters
 	instanceFilter := filter.New()
 	instanceFilter.AddGeneralRule(filter.OlderThanXDays(thresholds["notify-instances-older-than-days"]))

--- a/cmd/cloudsweeper/config.go
+++ b/cmd/cloudsweeper/config.go
@@ -49,9 +49,9 @@ var configMapping = map[string]lookup{
 
 	// Clean thresholds
 	"clean-untagged-older-than-days":    lookup{"CLEAN_UNTAGGED_OLDER_THAN_DAYS", "30"},
-	"clean-instances-older-than-days":   lookup{"CLEAN_INSTANCES_OLDER_THAN_DAYS", "180"},
-	"clean-images-older-than-days":      lookup{"CLEAN_IMAGES_OLDER_THAN_DAYS", "180"},
-	"clean-snapshots-older-than-days":   lookup{"CLEAN_SNAPSHOTS_OLDER_THAN_DAYS", "180"},
+	"clean-instances-older-than-days":   lookup{"CLEAN_INSTANCES_OLDER_THAN_DAYS", "182"},
+	"clean-images-older-than-days":      lookup{"CLEAN_IMAGES_OLDER_THAN_DAYS", "182"},
+	"clean-snapshots-older-than-days":   lookup{"CLEAN_SNAPSHOTS_OLDER_THAN_DAYS", "182"},
 	"clean-unattatched-older-than-days": lookup{"CLEAN_UNATTATCHED_OLDER_THAN_DAYS", "30"},
 	"clean-bucket-not-modified-days":    lookup{"CLEAN_BUCKET_NOT_MODIFIED_DAYS", "182"},
 	"clean-bucket-older-than-days":      lookup{"CLEAN_BUCKET_OLDER_THAN_DAYS", "7"},
@@ -62,7 +62,7 @@ var configMapping = map[string]lookup{
 	"notify-volumes-older-than-days":   lookup{"NOTIFY_VOLUMES_OLDER_THAN_DAYS", "30"},
 	"notify-snapshots-older-than-days": lookup{"NOTIFY_SNAPSHOTS_OLDER_THAN_DAYS", "30"},
 	"notify-buckets-older-than-days":   lookup{"NOTIFY_BUCKETS_OLDER_THAN_DAYS", "30"},
-	"notify-whitelist-older-than-days": lookup{"NOTIFY_WHITELIST_OLDER_THAN_DAYS", "180"},
+	"notify-whitelist-older-than-days": lookup{"NOTIFY_WHITELIST_OLDER_THAN_DAYS", "182"},
 	"notify-dnd-older-than-days":       lookup{"NOTIFY_DND_OLDER_THAN_DAYS", "7"},
 }
 

--- a/cmd/cloudsweeper/config.go
+++ b/cmd/cloudsweeper/config.go
@@ -57,13 +57,13 @@ var configMapping = map[string]lookup{
 	"clean-bucket-older-than-days":      lookup{"CLEAN_BUCKET_OLDER_THAN_DAYS", "7"},
 
 	//  Notify thresholds
-	"notify-instances-older-than-days": lookup{"NOTIFY_INSTANCES_OLDER_THAN_DAYS", "30"},
-	"notify-images-older-than-days":    lookup{"NOTIFY_IMAGES_OLDER_THAN_DAYS", "30"},
-	"notify-volumes-older-than-days":   lookup{"NOTIFY_VOLUMES_OLDER_THAN_DAYS", "30"},
-	"notify-snapshots-older-than-days": lookup{"NOTIFY_SNAPSHOTS_OLDER_THAN_DAYS", "30"},
-	"notify-buckets-older-than-days":   lookup{"NOTIFY_BUCKETS_OLDER_THAN_DAYS", "30"},
-	"notify-whitelist-older-than-days": lookup{"NOTIFY_WHITELIST_OLDER_THAN_DAYS", "182"},
-	"notify-dnd-older-than-days":       lookup{"NOTIFY_DND_OLDER_THAN_DAYS", "7"},
+	"notify-instances-older-than-days":  lookup{"NOTIFY_INSTANCES_OLDER_THAN_DAYS", "30"},
+	"notify-images-older-than-days":     lookup{"NOTIFY_IMAGES_OLDER_THAN_DAYS", "30"},
+	"notify-unattached-older-than-days": lookup{"NOTIFY_UNATTATCHED_OLDER_THAN_DAYS", "30"},
+	"notify-snapshots-older-than-days":  lookup{"NOTIFY_SNAPSHOTS_OLDER_THAN_DAYS", "30"},
+	"notify-buckets-older-than-days":    lookup{"NOTIFY_BUCKETS_OLDER_THAN_DAYS", "30"},
+	"notify-whitelist-older-than-days":  lookup{"NOTIFY_WHITELIST_OLDER_THAN_DAYS", "182"},
+	"notify-dnd-older-than-days":        lookup{"NOTIFY_DND_OLDER_THAN_DAYS", "7"},
 }
 
 func loadConfig() {

--- a/cmd/cloudsweeper/config.go
+++ b/cmd/cloudsweeper/config.go
@@ -49,15 +49,21 @@ var configMapping = map[string]lookup{
 
 	// Clean thresholds
 	"clean-untagged-older-than-days":    lookup{"CLEAN_UNTAGGED_OLDER_THAN_DAYS", "30"},
-	"clean-general-older-than-months":   lookup{"CLEAN_GENERAL_OLDER_THAN_MONTHS", "6"},
+	"clean-instances-older-than-days":   lookup{"CLEAN_INSTANCES_OLDER_THAN_DAYS", "180"},
+	"clean-images-older-than-days":      lookup{"CLEAN_IMAGES_OLDER_THAN_DAYS", "180"},
+	"clean-snapshots-older-than-days":   lookup{"CLEAN_SNAPSHOTS_OLDER_THAN_DAYS", "180"},
 	"clean-unattatched-older-than-days": lookup{"CLEAN_UNATTATCHED_OLDER_THAN_DAYS", "30"},
 	"clean-bucket-not-modified-days":    lookup{"CLEAN_BUCKET_NOT_MODIFIED_DAYS", "182"},
 	"clean-bucket-older-than-days":      lookup{"CLEAN_BUCKET_OLDER_THAN_DAYS", "7"},
 
 	//  Notify thresholds
-	"notify-general-older-than-days":     lookup{"NOTIFY_GENERAL_OLDER_THAN_DAYS", "30"},
-	"notify-whitelist-older-than-months": lookup{"NOTIFY_WHITELIST_OLDER_THAN_MONTHS", "6"},
-	"notify-dnd-older-than-days":         lookup{"NOTIFY_DND_OLDER_THAN_DAYS", "7"},
+	"notify-instances-older-than-days": lookup{"NOTIFY_INSTANCES_OLDER_THAN_DAYS", "30"},
+	"notify-images-older-than-days":    lookup{"NOTIFY_IMAGES_OLDER_THAN_DAYS", "30"},
+	"notify-volumes-older-than-days":   lookup{"NOTIFY_VOLUMES_OLDER_THAN_DAYS", "30"},
+	"notify-snapshots-older-than-days": lookup{"NOTIFY_SNAPSHOTS_OLDER_THAN_DAYS", "30"},
+	"notify-buckets-older-than-days":   lookup{"NOTIFY_BUCKETS_OLDER_THAN_DAYS", "30"},
+	"notify-whitelist-older-than-days": lookup{"NOTIFY_WHITELIST_OLDER_THAN_DAYS", "180"},
+	"notify-dnd-older-than-days":       lookup{"NOTIFY_DND_OLDER_THAN_DAYS", "7"},
 }
 
 func loadConfig() {

--- a/cmd/cloudsweeper/main.go
+++ b/cmd/cloudsweeper/main.go
@@ -58,26 +58,20 @@ var (
 	thresholds = make(map[string]int)
 	thnames    = []string{
 		"clean-untagged-older-than-days",
-		"clean-general-older-than-months",
+		"clean-instances-older-than-days",
+		"clean-images-older-than-days",
+		"clean-snapshots-older-than-days",
 		"clean-unattatched-older-than-days",
 		"clean-bucket-not-modified-days",
 		"clean-bucket-older-than-days",
-		"notify-general-older-than-days",
-		"notify-whitelist-older-than-months",
+		"notify-instances-older-than-days",
+		"notify-images-older-than-days",
+		"notify-volumes-older-than-days",
+		"notify-snapshots-older-than-days",
+		"notify-buckets-older-than-days",
+		"notify-whitelist-older-than-days",
 		"notify-dnd-older-than-days",
 	}
-
-	// Clean thresholds
-	cleanUntaggedOlderThanDays    = flag.String("clean-untagged-older-than-days", "", "Clean untagged instances if older than X days (default: 30)")
-	cleanGeneralOlderThanMonths   = flag.String("clean-general-older-than-months", "", "Clean if older than X days (default: 6)")
-	cleanUnattatchedOlderThanDays = flag.String("clean-unattatched-older-than-days", "", "Clean unattached volumes older than X days (default: 30)")
-	cleanBucketNotModifiedDays    = flag.String("clean-bucket-not-modified-days", "", "Clean s3 bucket if not modified for more than X days (default: 182)")
-	cleanBucketOlderThanDays      = flag.String("clean-bucket-older-than-days", "", "Clean s3 bucket if older than X days (default: 7)")
-
-	//  Notify thresholds
-	notifyGeneralOlderThanDays     = flag.String("notify-general-older-than-days", "", "Notify if older than X days (default: 30)")
-	notifyWhitelistOlderThanMonths = flag.String("notify-whitelist-older-than-months", "", "Notify if whitelisted is older than X months (default: 6)")
-	notifyDndOlderThanDays         = flag.String("notify-dnd-older-than-days", "", "Do not delete older than X days (default: 7)")
 )
 
 const banner = `

--- a/cmd/cloudsweeper/main.go
+++ b/cmd/cloudsweeper/main.go
@@ -66,7 +66,7 @@ var (
 		"clean-bucket-older-than-days",
 		"notify-instances-older-than-days",
 		"notify-images-older-than-days",
-		"notify-volumes-older-than-days",
+		"notify-unattached-older-than-days",
 		"notify-snapshots-older-than-days",
 		"notify-buckets-older-than-days",
 		"notify-whitelist-older-than-days",
@@ -85,7 +85,7 @@ var (
 	//  Notify thresholds
 	notifyInstancesOlderThanDays = flag.String("notify-instances-older-than-days", "", "Notify if instances is older than X days (default: 30)")
 	notifyImagesOlderThanDays    = flag.String("notify-images-older-than-days", "", "Notify if image is older than X days (default: 30)")
-	notifyVolumesOlderThanDays   = flag.String("notify-volumes-older-than-days", "", "Notify if volume is older than X days (default: 30)")
+	notifyVolumesOlderThanDays   = flag.String("notify-unattached-older-than-days", "", "Notify if volume is older than X days (default: 30)")
 	notifySnapshotsOlderThanDays = flag.String("notify-snapshots-older-than-days", "", "Notify if snapshot is older than X days (default: 30)")
 	notifyBucketsOlderThanDays   = flag.String("notify-buckets-older-than-days", "", "Notify if bucket is older than X days (default: 30)")
 	notifyWhitelistOlderThanDays = flag.String("notify-whitelist-older-than-days", "", "Notify if whitelisted is older than X days (default: 182)")

--- a/cmd/cloudsweeper/main.go
+++ b/cmd/cloudsweeper/main.go
@@ -72,6 +72,24 @@ var (
 		"notify-whitelist-older-than-days",
 		"notify-dnd-older-than-days",
 	}
+
+	// Clean thresholds
+	cleanUntaggedOlderThanDays    = flag.String("clean-untagged-older-than-days", "", "Clean untagged instances if older than X days (default: 30)")
+	cleanInstancesOlderThanDays   = flag.String("clean-instances-older-than-days", "", "Clean if instance is older than X days (default: 182)")
+	cleanImagesOlderThanDays      = flag.String("clean-images-older-than-days", "", "Clean if image is older than X days (default: 182)")
+	cleanSnapshotsOlderThanDays   = flag.String("clean-snapshots-older-than-days", "", "Clean if snapshot is older than X days (default: 182)")
+	cleanUnattatchedOlderThanDays = flag.String("clean-unattatched-older-than-days", "", "Clean unattached volumes older than X days (default: 30)")
+	cleanBucketNotModifiedDays    = flag.String("clean-bucket-not-modified-days", "", "Clean s3 bucket if not modified for more than X days (default: 182)")
+	cleanBucketOlderThanDays      = flag.String("clean-bucket-older-than-days", "", "Clean s3 bucket if older than X days (default: 7)")
+
+	//  Notify thresholds
+	notifyInstancesOlderThanDays = flag.String("notify-instances-older-than-days", "", "Notify if instances is older than X days (default: 30)")
+	notifyImagesOlderThanDays    = flag.String("notify-images-older-than-days", "", "Notify if image is older than X days (default: 30)")
+	notifyVolumesOlderThanDays   = flag.String("notify-volumes-older-than-days", "", "Notify if volume is older than X days (default: 30)")
+	notifySnapshotsOlderThanDays = flag.String("notify-snapshots-older-than-days", "", "Notify if snapshot is older than X days (default: 30)")
+	notifyBucketsOlderThanDays   = flag.String("notify-buckets-older-than-days", "", "Notify if bucket is older than X days (default: 30)")
+	notifyWhitelistOlderThanDays = flag.String("notify-whitelist-older-than-days", "", "Notify if whitelisted is older than X days (default: 182)")
+	notifyDndOlderThanDays       = flag.String("notify-dnd-older-than-days", "", "Do not delete older than X days (default: 7)")
 )
 
 const banner = `

--- a/config.conf
+++ b/config.conf
@@ -82,19 +82,31 @@ CS_MASTER_ARN: arn:aws:iam::123456789123:user/cloudsweeper-master
 
 ########################## Thresholds ##############################
 # CLEAN_UNTAGGED_OLDER_THAN_DAYS defines the number of days before an untagged instance is cleaned up
-# CLEAN_UNTAGGED_OLDER_THAN_DAYS: 
-# CLEAN_GENERAL_OLDER_THAN_MONTHS defines the number of months before items are cleaned up in AWS
-# CLEAN_GENERAL_OLDER_THAN_MONTHS: 
+# CLEAN_UNTAGGED_OLDER_THAN_DAYS: 30
+# CLEAN_INSTANCES_OLDER_THAN_DAYS defines the number of days before an instance is cleaned up
+# CLEAN_INSTANCES_OLDER_THAN_DAYS: 180
+# CLEAN_IMAGES_OLDER_THAN_DAYS defines the number of days before an instance is cleaned up
+# CLEAN_IMAGES_OLDER_THAN_DAYS: 180
+# CLEAN_SNAPSHOTS_OLDER_THAN_DAYS defines the number of days before an instance is cleaned up
+# CLEAN_SNAPSHOTS_OLDER_THAN_DAYS: 180
 # CLEAN_UNATTATCHED_OLDER_THAN_DAYS defines the number of days before an unattached volume is cleaned up
-# CLEAN_UNATTATCHED_OLDER_THAN_DAYS: 
+# CLEAN_UNATTATCHED_OLDER_THAN_DAYS: 30
 # CLEAN_BUCKET_NOT_MODIFIED_DAYS defines the number of days that an S3 bucket must be idle for before cleanup occours
-# CLEAN_BUCKET_NOT_MODIFIED_DAYS:
+# CLEAN_BUCKET_NOT_MODIFIED_DAYS: 182
 # CLEAN_BUCKET_OLDER_THAN_DAYS defines the number of days than an S3 bucket must exist for before being cleaned up
-# CLEAN_BUCKET_OLDER_THAN_DAYS:
+# CLEAN_BUCKET_OLDER_THAN_DAYS: 7
 
-# NOTIFY_GENERAL_OLDER_THAN_DAYS defines the number of days before notifications are sent out
-# NOTIFY_GENERAL_OLDER_THAN_DAYS:
-# NOTIFY_WHITELIST_OLDER_THAN_MONTHS defines the number of months before notifications are sent out for whitelisted items
-# NOTIFY_WHITELIST_OLDER_THAN_MONTHS:
+# NOTIFY_INSTANCES_OLDER_THAN_DAYS defines the number of days before notifications are sent out for instances
+# NOTIFY_INSTANCES_OLDER_THAN_DAYS: 30
+# NOTIFY_IMAGES_OLDER_THAN_DAYS defines the number of days before notifications are sent out for images
+# NOTIFY_IMAGES_OLDER_THAN_DAYS: 30
+# NOTIFY_VOLUMES_OLDER_THAN_DAYS defines the number of days before notifications are sent out for volumes
+# NOTIFY_VOLUMES_OLDER_THAN_DAYS: 30
+# NOTIFY_SNAPSHOTS_OLDER_THAN_DAYS defines the number of days before notifications are sent out for snapshots
+# NOTIFY_SNAPSHOTS_OLDER_THAN_DAYS: 30
+# NOTIFY_BUCKETS_OLDER_THAN_DAYS defines the number of days before notifications are sent out for buckets
+# NOTIFY_BUCKETS_OLDER_THAN_DAYS: 30
+# NOTIFY_WHITELIST_OLDER_THAN_DAYS defines the number of days before notifications are sent out for whitelisted items
+# NOTIFY_WHITELIST_OLDER_THAN_DAYS: 180
 # NOTIFY_DND_OLDER_THAN_DAYS defines the number of days that a Do Not Destroy tag must exist for before sending out a notification
-# NOTIFY_DND_OLDER_THAN_DAYS:
+# NOTIFY_DND_OLDER_THAN_DAYS: 7


### PR DESCRIPTION
Split up the general thresholds into resource specific ones. This way we have more flexibility with how often we want to clean things up.