### PR TITLE
Add support for computing price of all bucket types (for AWS)

### DIFF
--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/sts"
+
 	"github.com/aws/aws-sdk-go/aws"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -567,6 +569,25 @@ func getAllEC2Resources(accounts []string, funcToRun func(client *ec2.EC2, accou
 	forEachAccount(accounts, sess, func(account string, cred *credentials.Credentials) {
 		log.Println("Accessing account", account)
 		forEachAWSRegion(func(region string) {
+			// Check if region is enabled
+			stsClient := sts.New(sess, &aws.Config{
+				Credentials: cred,
+				Region:      aws.String(region),
+			})
+			_, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+			if err != nil {
+				// Ensure that we can make the default call, otherwise we have other problems
+				stsClient = sts.New(sess, &aws.Config{
+					Credentials: cred,
+				})
+				_, err = stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+				if err == nil {
+					log.Printf("Region %s is disabled, skipping it!", region)
+					return
+				} else {
+					log.Fatalf("Unknown AWS error %s", err)
+				}
+			}
 			client := ec2.New(sess, &aws.Config{
 				Credentials: cred,
 				Region:      aws.String(region),

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -63,6 +63,16 @@ var (
 	errAWSRequestLimit = errors.New("aws request limit hit")
 )
 
+var awsS3StorageTypes = []string{
+	"StandardStorage",
+	"IntelligentTieringFAStorage",
+	"IntelligentTieringIAStorage",
+	"StandardIAStorage",
+	"OneZoneIAStorage",
+	"ReducedRedundancyStorage",
+	"GlacierStorage",
+}
+
 func (m *awsResourceManager) InstancesPerAccount() map[string][]Instance {
 	log.Println("Getting instances in all accounts")
 	resultMap := make(map[string][]Instance)
@@ -231,7 +241,7 @@ func (m *awsResourceManager) BucketsPerAccount() map[string][]Bucket {
 					cw := cloudwatch.New(sess, &aws.Config{
 						Credentials: cred,
 						Region:      aws.String(region)})
-					size := 0
+					storageTypeSizesGB := make(map[string]float64)
 					numberOfObjects := int64(0)
 
 					var input cloudwatch.GetMetricStatisticsInput
@@ -246,34 +256,40 @@ func (m *awsResourceManager) BucketsPerAccount() map[string][]Bucket {
 						Name:  aws.String("BucketName"),
 						Value: bu.Name,
 					}
-					dimensionBucketSizeFilter := cloudwatch.Dimension{
-						Name:  aws.String("StorageType"),
-						Value: aws.String("StandardStorage"),
-					}
-					input.Dimensions = []*cloudwatch.Dimension{
-						&dimensionNameFilter, &dimensionBucketSizeFilter,
-					}
-					bucketSizeMetrics, err := cw.GetMetricStatistics(&input)
-					if err != nil {
-						fmt.Println("Error", err)
-					}
-					if bucketSizeMetrics != nil {
-						var minimumTimeDifference float64
-						var timeDifference float64
-						var averageValue *float64
-						minimumTimeDifference = -1
-						for _, datapoint := range bucketSizeMetrics.Datapoints {
-							timeDifference = time.Since(*datapoint.Timestamp).Seconds()
-							if minimumTimeDifference == -1 {
-								minimumTimeDifference = timeDifference
-								averageValue = datapoint.Average
-							} else if timeDifference < minimumTimeDifference {
-								minimumTimeDifference = timeDifference
-								averageValue = datapoint.Average
-							}
+
+					// Get sizes for all storage types
+					numBucketSizeDatapoints := 0
+					for _, storageType := range awsS3StorageTypes {
+						dimensionBucketSizeFilter := cloudwatch.Dimension{
+							Name:  aws.String("StorageType"),
+							Value: aws.String(storageType),
 						}
-						if averageValue != nil {
-							size = int(*averageValue)
+						input.Dimensions = []*cloudwatch.Dimension{
+							&dimensionNameFilter, &dimensionBucketSizeFilter,
+						}
+						bucketSizeMetrics, err := cw.GetMetricStatistics(&input)
+						if err != nil {
+							fmt.Println("Error", err)
+						}
+						if bucketSizeMetrics != nil {
+							var minimumTimeDifference float64
+							var timeDifference float64
+							var averageValue *float64
+							minimumTimeDifference = -1
+							for _, datapoint := range bucketSizeMetrics.Datapoints {
+								timeDifference = time.Since(*datapoint.Timestamp).Seconds()
+								if minimumTimeDifference == -1 {
+									minimumTimeDifference = timeDifference
+									averageValue = datapoint.Average
+								} else if timeDifference < minimumTimeDifference {
+									minimumTimeDifference = timeDifference
+									averageValue = datapoint.Average
+								}
+							}
+							if averageValue != nil {
+								storageTypeSizesGB[storageType] = float64(*averageValue) / gbDivider
+							}
+							numBucketSizeDatapoints += len(bucketSizeMetrics.Datapoints)
 						}
 					}
 
@@ -291,7 +307,7 @@ func (m *awsResourceManager) BucketsPerAccount() map[string][]Bucket {
 					if err != nil {
 						fmt.Println("Error", err)
 					}
-					if len(bucketSizeMetrics.Datapoints) == 0 && len(numberOfObjectsMetrics.Datapoints) != 0 {
+					if numBucketSizeDatapoints == 0 && len(numberOfObjectsMetrics.Datapoints) != 0 {
 						fmt.Println("Warning: Got 0 datapoints from: ", *bu.Name)
 					}
 					if numberOfObjectsMetrics != nil {
@@ -337,6 +353,11 @@ func (m *awsResourceManager) BucketsPerAccount() map[string][]Bucket {
 						return
 					}
 
+					totalSizeGB := 0.0
+					for _, size := range storageTypeSizesGB {
+						totalSizeGB += size
+					}
+
 					buck := awsBucket{baseBucket{
 						baseResource: baseResource{
 							csp:          AWS,
@@ -346,9 +367,10 @@ func (m *awsResourceManager) BucketsPerAccount() map[string][]Bucket {
 							creationTime: *bu.CreationDate,
 							tags:         tags,
 						},
-						lastModified: lastMod,
-						objectCount:  numberOfObjects,
-						totalSizeGB:  float64(size) / gbDivider,
+						lastModified:       lastMod,
+						objectCount:        numberOfObjects,
+						totalSizeGB:        totalSizeGB,
+						storageTypeSizesGB: storageTypeSizesGB,
 					}}
 					buckChan <- &buck
 				}(bu, buckChan)

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -569,7 +569,7 @@ func getAllEC2Resources(accounts []string, funcToRun func(client *ec2.EC2, accou
 	forEachAccount(accounts, sess, func(account string, cred *credentials.Credentials) {
 		log.Println("Accessing account", account)
 		forEachAWSRegion(func(region string) {
-			// Check if region is enabled
+			// Check if region is enabled by making a call that we should always have permissions for
 			stsClient := sts.New(sess, &aws.Config{
 				Credentials: cred,
 				Region:      aws.String(region),

--- a/cloud/bucket.go
+++ b/cloud/bucket.go
@@ -18,9 +18,10 @@ import (
 
 type baseBucket struct {
 	baseResource
-	lastModified time.Time
-	objectCount  int64
-	totalSizeGB  float64
+	lastModified       time.Time
+	objectCount        int64
+	totalSizeGB        float64
+	storageTypeSizesGB map[string]float64
 }
 
 func (b *baseBucket) LastModified() time.Time {
@@ -33,6 +34,10 @@ func (b *baseBucket) ObjectCount() int64 {
 
 func (b *baseBucket) TotalSizeGB() float64 {
 	return b.totalSizeGB
+}
+
+func (b *baseBucket) StorageTypeSizesGB() map[string]float64 {
+	return b.storageTypeSizesGB
 }
 
 func cleanupBuckets(buckets []Bucket) error {

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -121,6 +121,7 @@ type Bucket interface {
 	LastModified() time.Time
 	ObjectCount() int64
 	TotalSizeGB() float64
+	StorageTypeSizesGB() map[string]float64
 }
 
 // ResourceCollection encapsulates collections of multiple resources. Does not

--- a/cloud/filter/rules_test.go
+++ b/cloud/filter/rules_test.go
@@ -327,9 +327,10 @@ type testBucket struct {
 	lastModified time.Time
 }
 
-func (b *testBucket) LastModified() time.Time { return b.lastModified }
-func (b *testBucket) ObjectCount() int64      { return 10 }
-func (b *testBucket) TotalSizeGB() float64    { return 5.13 }
+func (b *testBucket) LastModified() time.Time                { return b.lastModified }
+func (b *testBucket) ObjectCount() int64                     { return 10 }
+func (b *testBucket) TotalSizeGB() float64                   { return 5.13 }
+func (b *testBucket) StorageTypeSizesGB() map[string]float64 { return make(map[string]float64) }
 
 func TestNotModified(t *testing.T) {
 	foo := &testBucket{

--- a/cloud/gcp.go
+++ b/cloud/gcp.go
@@ -454,9 +454,10 @@ func (m *gcpResourceManager) getBuckets(project string) ([]Bucket, error) {
 					public:       false,
 					location:     buck.Location,
 				},
-				lastModified: lastModified,
-				objectCount:  count,
-				totalSizeGB:  size,
+				lastModified:       lastModified,
+				objectCount:        count,
+				totalSizeGB:        size,
+				storageTypeSizesGB: make(map[string]float64),
 			},
 			storage: m.storage,
 		})


### PR DESCRIPTION
Currently we are only fetching the size of the standard storage class and ignore all others.

With this change, we look up the sizes of all the different storage types so that the final price estimate can have contributions from all of them.

Note that the prices are still hardcoded, but ideally we would look them up every time.

Still WIP, since I could test against dev account which only has StandardStorage. Need to change some of the buckets in dev to a different type to verify that this is working as intended.