### PR TITLE
Negate wrong do-not-delete rule

### DIFF
--- a/cloudsweeper/notify/notify.go
+++ b/cloudsweeper/notify/notify.go
@@ -195,7 +195,7 @@ func (c *Client) OldResourceReview(mngr cloud.ResourceManager, org *cs.Organizat
 
 	// This only applies to instances
 	dndFilter := filter.New()
-	dndFilter.AddGeneralRule(filter.HasTag("cloudsweeper-do-not-delete"))
+	dndFilter.AddGeneralRule(filter.Negate(filter.HasTag("cloudsweeper-do-not-delete")))
 	dndFilter.AddGeneralRule(filter.OlderThanXDays(getThreshold("notify-dnd-older-than-days", thresholds)))
 
 	for account, resources := range allCompute {


### PR DESCRIPTION
One-line change.

Currently everything with the tag shows up. We want the opposite. 