### PR TITLE
add error handling for tagging pull

### DIFF
--- a/cloud/bucket.go
+++ b/cloud/bucket.go
@@ -124,7 +124,7 @@ func (b *awsBucket) SetTag(key, value string, overwrite bool) error {
 		Credentials: creds,
 		Region:      aws.String(b.Location()),
 	})
-	
+
 	tagging := &s3.Tagging{
 		TagSet: []*s3.Tag{{
 			Key:   aws.String(key),
@@ -145,10 +145,7 @@ func (b *awsBucket) SetTag(key, value string, overwrite bool) error {
 	return err
 }
 
-// RemoveTag removes the specified tag from the bucket by first deleting all tags
-// and then adding back all the other tags. Note that this is potentially unsafe if
-// the program crashes in the middle of the function. Unfortunately there doesn't seem
-// to be an API call for removing a specific tag from a bucket...
+// RemoveTag removes the specified tag from the bucket
 func (b *awsBucket) RemoveTag(tagToRemove string) error {
 	sess := session.Must(session.NewSession())
 	creds := stscreds.NewCredentials(sess, fmt.Sprintf(assumeRoleARNTemplate, b.Owner()))
@@ -156,12 +153,7 @@ func (b *awsBucket) RemoveTag(tagToRemove string) error {
 		Credentials: creds,
 		Region:      aws.String(b.Location()),
 	})
-	_, err := s3Client.DeleteBucketTagging(&s3.DeleteBucketTaggingInput{
-		Bucket: aws.String(b.ID()),
-	})
-	if err != nil {
-		return err
-	}
+	
 	tagging := &s3.Tagging{
 		TagSet: []*s3.Tag{},
 	}
@@ -178,7 +170,7 @@ func (b *awsBucket) RemoveTag(tagToRemove string) error {
 		Bucket:  aws.String(b.ID()),
 		Tagging: tagging,
 	}
-	_, err = s3Client.PutBucketTagging(input)
+	_, err := s3Client.PutBucketTagging(input)
 	return err
 }
 


### PR DESCRIPTION
Adds error handling for getting bucket tags, and removed an unneeded "delete all tags" call in the cloudsweeper reset flow. 